### PR TITLE
Added file license header #14 #13 #15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+What's changed since pre-release v0.1.0-B2012007:
+
+- Updated rules:
+  - Added support for checking license header in `Dockerfile`, `.rb`, `.bicep`, `.cmd`, `.bat`. [#14](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/14)
+  - Added support for checking if `SUPPORT.md` exists. [#13](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/13)
+- Engineering:
+  - Bump PSRule dependency to v1.2.0. [#15](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/15)
+
 ## v0.1.0-B2012007 (pre-release)
 
 - Initial pre-release.

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -108,7 +108,7 @@ task VersionModule ModuleDependencies, {
     $manifest = Test-ModuleManifest -Path $manifestPath;
     $requiredModules = $manifest.RequiredModules | ForEach-Object -Process {
         if ($_.Name -eq 'PSRule' -and $Configuration -eq 'Release') {
-            @{ ModuleName = 'PSRule'; ModuleVersion = '1.0.0' }
+            @{ ModuleName = 'PSRule'; ModuleVersion = '1.2.0' }
         }
         else {
             @{ ModuleName = $_.Name; ModuleVersion = $_.Version }
@@ -155,16 +155,16 @@ task PSScriptAnalyzer NuGet, {
 
 # Synopsis: Install PSRule
 task PSRule NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.0.0 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.0.0 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 1.2.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 1.2.0 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSRule -Verbose:$False;
 }
 
 # Synopsis: Install PSDocs
 task PSDocs NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion 0.6.3 -ErrorAction Ignore)) {
-        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion 0.6.3 -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion 0.8.0 -ErrorAction Ignore)) {
+        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion 0.8.0 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSDocs -Verbose:$False;
 }

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,7 +16,7 @@ bugs:
   url: https://github.com/Microsoft/PSRule.Rules.MSFT.OSS/issues
 
 modules:
-  PSRule: ^1.0.0
+  PSRule: ^1.2.0
 
 tasks:
   clear:

--- a/src/PSRule.Rules.MSFT.OSS/MSFT.OSS.Rule.ps1
+++ b/src/PSRule.Rules.MSFT.OSS/MSFT.OSS.Rule.ps1
@@ -7,13 +7,14 @@ Rule 'MSFT.OSS.Community' -Type 'PSRule.Data.RepositoryInfo' {
     $Assert.FilePath($TargetObject, 'FullName', @('CODE_OF_CONDUCT.md'));
     $Assert.FilePath($TargetObject, 'FullName', @('CONTRIBUTING.md'));
     $Assert.FilePath($TargetObject, 'FullName', @('SECURITY.md'));
+    $Assert.FilePath($TargetObject, 'FullName', @('SUPPORT.md'));
     $Assert.FilePath($TargetObject, 'FullName', @('README.md'));
     $Assert.FilePath($TargetObject, 'FullName', @('.github/CODEOWNERS'));
     $Assert.FilePath($TargetObject, 'FullName', @('.github/PULL_REQUEST_TEMPLATE.md'));
 }
 
 # Synopsis: Check for license in code files
-Rule 'MSFT.OSS.License' -Type '.cs', '.ps1', '.psd1', '.psm1', '.ts', '.js', '.fs', '.go', '.php', '.cpp', '.h', '.r', '.py', '.sh', '.pl' {
+Rule 'MSFT.OSS.License' -Type '.cs', '.ps1', '.psd1', '.psm1', '.ts', '.js', '.fs', '.go', '.php', '.cpp', '.h', '.r', '.rb', '.py', '.sh', '.pl', '.bicep', 'Dockerfile', '.bat', '.cmd' {
     $Assert.FileHeader($TargetObject, 'FullName', @(
         'Copyright (c) Microsoft Corporation.'
         'Licensed under the MIT License.'

--- a/tests/PSRule.Rules.MSFT.OSS.Tests/MSFT.OSS.Rule.Tests.ps1
+++ b/tests/PSRule.Rules.MSFT.OSS.Tests/MSFT.OSS.Rule.Tests.ps1
@@ -19,7 +19,6 @@ if ($Env:SYSTEM_DEBUG -eq 'true') {
 # Setup tests paths
 $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.MSFT.OSS) -Force;
-$here = Join-Path -Path $rootPath -ChildPath 'tests/PSRule.Rules.MSFT.OSS.Tests/';
 
 Describe 'MSFT.OSS' -Tag 'name' {
     $invokeParams = @{
@@ -52,12 +51,20 @@ Describe 'MSFT.OSS' -Tag 'name' {
                 $Null = New-Item -Path $testPath -ItemType Directory -Force;
             }
             $extentionsSlash = @('.cs', '.ts', '.js', '.fs', '.go', '.php', '.cpp', '.h')
-            $extentionsHash = @('.ps1')
+            $extentionsHash = @('.ps1', '.r', '.py', '.rb', '.sh')
+            $extentionsColon = @('.bat', '.cmd')
+            $fileHash = @('Dockerfile')
             foreach ($ext in $extentionsSlash) {
                 $Null = Set-Content -Path (Join-Path -Path $testPath -ChildPath "file$ext") -Value '// An example value';
             }
             foreach ($ext in $extentionsHash) {
                 $Null = Set-Content -Path (Join-Path -Path $testPath -ChildPath "file$ext") -Value '`# An example value';
+            }
+            foreach ($ext in $extentionsColon) {
+                $Null = Set-Content -Path (Join-Path -Path $testPath -ChildPath "file$ext") -Value ':: An example value';
+            }
+            foreach ($ext in $fileHash) {
+                $Null = Set-Content -Path (Join-Path -Path $testPath -ChildPath "$ext") -Value '`# An example value';
             }
 
             # Check rule
@@ -65,7 +72,7 @@ Describe 'MSFT.OSS' -Tag 'name' {
             try {
                 $ruleResult = @(Invoke-PSRule @invokeParams -InputPath $testPath -Name 'MSFT.OSS.License');
                 $ruleResult | Should -Not -BeNullOrEmpty;
-                $ruleResult.Length | Should -Be ($extentionsSlash.Length + $extentionsHash.Length);
+                $ruleResult.Length | Should -Be ($extentionsSlash.Length + $extentionsHash.Length + $extentionsColon.Length + $fileHash.Length);
                 $ruleResult.Outcome | Should -BeIn 'Fail';
             }
             finally {


### PR DESCRIPTION
## PR Summary

- Updated rules:
  - Added support for checking license header in `Dockerfile`, `.rb`, `.bicep`, `.cmd`, `.bat`. #14
  - Added support for checking if `SUPPORT.md` exists. #13
- Engineering:
  - Bump PSRule dependency to v1.2.0. #15

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule.Rules.MSFT.OSS/blob/main/CHANGELOG.md) has been updated with change under unreleased section
