### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v1.0.0
+
+What's changed since v0.1.0:
+
+- Updated rules:
+  - Updated rule documentation links. [#25](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/25)
+- Engineering:
+  - Bump PSRule dependency to v1.10.0. [#24](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/24)
+
+What's changed since pre-release v1.0.0-B2112003:
+
+- No additional changes.
+
 ## v1.0.0-B2112003 (pre-release)
 
 What's changed since v0.1.0:


### PR DESCRIPTION
## PR Summary

What's changed since v0.1.0:

- Updated rules:
  - Updated rule documentation links. #25
- Engineering:
  - Bump PSRule dependency to v1.10.0. #24

What's changed since pre-release v1.0.0-B2112003:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
