### PR TITLE
Pre-release v1.1.0-B2205007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.1.0-B2205007 (pre-release)
+
 What's changed since pre-release v1.1.0-B2204005:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.1.0-B2204005:

- Engineering:
  - Bump PSRule to v2.1.0. [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)
  - Bump Pester to v5.3.3. [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
