### PR TITLE
Pre-release v1.1.0-B2207007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,41 +2,50 @@
 
 ## Unreleased
 
+## v1.1.0-B2207007 (pre-release)
+
 What's changed since pre-release v1.1.0-B2205007:
 
 - Engineering:
-  - Bump PSRule to v2.2.0. [#44](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/44)
+  - Bump PSRule to v2.2.0.
+    [#44](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/44)
 
 ## v1.1.0-B2205007 (pre-release)
 
 What's changed since pre-release v1.1.0-B2204005:
 
 - Engineering:
-  - Bump PSRule to v2.1.0. [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)
-  - Bump Pester to v5.3.3. [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)
+  - Bump PSRule to v2.1.0.
+    [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)
+  - Bump Pester to v5.3.3.
+    [#40](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/40)
 
 ## v1.1.0-B2204005 (pre-release)
 
 What's changed since v1.0.1:
 
 - Engineering:
-  - Bump PSRule to v2.0.1. [#35](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/35)
+  - Bump PSRule to v2.0.1.
+    [#35](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/35)
 
 ## v1.0.1
 
 What's changed since v1.0.0:
 
 - Bug fixes:
-  - Fixed online documentation links. [#30](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/30)
+  - Fixed online documentation links by @BernieWhite.
+    [#30](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/30)
 
 ## v1.0.0
 
 What's changed since v0.1.0:
 
 - Updated rules:
-  - Updated rule documentation links. [#25](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/25)
+  - Updated rule documentation links by @BernieWhite.
+    [#25](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/25)
 - Engineering:
-  - Bump PSRule to v1.10.0. [#24](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/24)
+  - Bump PSRule to v1.10.0.
+    [#24](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/24)
 
 What's changed since pre-release v1.0.0-B2112003:
 
@@ -47,9 +56,11 @@ What's changed since pre-release v1.0.0-B2112003:
 What's changed since v0.1.0:
 
 - Updated rules:
-  - Updated rule documentation links. [#25](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/25)
+  - Updated rule documentation links by @BernieWhite.
+    [#25](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/25)
 - Engineering:
-  - Bump PSRule to v1.10.0. [#24](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/24)
+  - Bump PSRule to v1.10.0.
+    [#24](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/24)
 
 ## v0.1.0
 
@@ -64,10 +75,13 @@ What's changed since pre-release v0.1.0-B2104002:
 What's changed since pre-release v0.1.0-B2012007:
 
 - Updated rules:
-  - Added support for checking license header in `Dockerfile`, `.rb`, `.bicep`, `.cmd`, `.bat`. [#14](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/14)
-  - Added support for checking if `SUPPORT.md` exists. [#13](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/13)
+  - Added support for checking license header in `Dockerfile`, `.rb`, `.bicep`, `.cmd`, `.bat` by @BernieWhite.
+    [#14](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/14)
+  - Added support for checking if `SUPPORT.md` exists by @BernieWhite.
+    [#13](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/13)
 - Engineering:
-  - Bump PSRule to v1.2.0. [#15](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/15)
+  - Bump PSRule to v1.2.0.
+    [#15](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/issues/15)
 
 ## v0.1.0-B2012007 (pre-release)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.1.0-B2205007:

- Engineering:
  - Bump PSRule to v2.2.0.
    [#44](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/44)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
