### PR TITLE
Pre-release v1.1.0-B2301014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.1.0-B2301014 (pre-release)
+
 What's changed since pre-release v1.1.0-B2207007:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.1.0-B2207007:

- Engineering:
  - Bump PSRule to v2.7.0.
    [#59](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/59)
  - Bump Pester to v5.4.0.
    [#59](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/59)
  - Bump PSScriptAnalyzer to v1.21.0.
    [#46](https://github.com/microsoft/PSRule.Rules.MSFT.OSS/pull/46)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
